### PR TITLE
Use JSHint to show common JS syntax issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = function(gulp, options) {
   gulp.task('browserify', getTask('browserify', config));
   gulp.task('browserSync', ['watch'], getTask('browserSync', config));
   gulp.task('uglifyJs', getTask('uglifyJs', config));
+  gulp.task('jshint', getTask('jshint', config));
   gulp.task('minifyCss', ['sass'], getTask('minifyCss', config));
   gulp.task('production', ['minifyCss', 'uglifyJs']);
   gulp.task('default', config.default.tasks);

--- a/lib/config/jshint.js
+++ b/lib/config/jshint.js
@@ -1,0 +1,12 @@
+var merge = require('../util/mergeOptions.js');
+
+module.exports = function(options) {
+  // The default configuration
+  var defaults = {
+    reporterConfig: {
+      verbose: true
+    }
+  };
+
+  return merge('jshint', options, defaults);
+};

--- a/lib/config/setup.js
+++ b/lib/config/setup.js
@@ -14,6 +14,7 @@ module.exports = function(options) {
   options.symbols       = defaults.symbols(options);
   options.static        = defaults.static(options);
   options.browserSync   = defaults.browserSync(options);
+  options.jshint        = defaults.jshint(options);
   options.uglifyJs      = defaults.uglifyJs(options);
   options.default       = defaults.default(options);
   options.watch         = defaults.watch(options);

--- a/lib/tasks/jshint.js
+++ b/lib/tasks/jshint.js
@@ -1,0 +1,13 @@
+var p = require('path');
+var jshint = require('gulp-jshint');
+var stylish = require('jshint-stylish');
+
+module.exports = function(gulp, plugins, config) {
+	var src = p.join(config.assets.scripts, '**/*.js');
+
+	return function() {
+		return gulp.src(src)
+		    .pipe(jshint())
+		    .pipe(jshint.reporter(stylish, config.jshint.reporterConfig));
+	};
+};

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-iconfont": "^1.0.0",
     "gulp-if": "1.2.5",
     "gulp-imagemin": "^2.3.0",
+    "gulp-jshint": "~1.11.2",
     "gulp-load-plugins": "^1.0.0-rc.1",
     "gulp-minify-css": "^1.1.1",
     "gulp-notify": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4",
     "js-beautify": "^1.5.10",
+    "jshint": "~2.8.0",
+    "jshint-stylish": "~2.0.1",
     "lazypipe": "^1.0.1",
     "lodash": "^3.9.3",
     "minimatch": "^2.0.8",


### PR DESCRIPTION
This task uses JSHint to report JavaScript syntax issues in the console.  See http://jshint.com/docs/ for full information on what is being looked for.

Use `gulp jshint` to have it run through JS files inside `config.assets.scripts`.
