### PR TITLE
Catching error when a package.json exists, but is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,23 +383,21 @@ gulp.task('my-custom-task', function() {
 
 ### `browserSync`
 
-Starts Browser Sync and runs `watch` in tandem.
+Starts [Browser Sync](http://www.browsersync.io/docs/options/) and runs `watch` in tandem.
 
 **Options:**
 ```javascript
 config.browserSync = {
-  useBrowserSync: true,
-  // For all available settings: http://www.browsersync.io/docs/options/
-  settings: {
-    server: appDir,
-    open: true,
-    notify: false,
-    reloadOnRestart: true,
-    files: [
-      p.join(assets.root, '**/*'),
-      p.join(appDir, '**/*.php'),
-    ]
-  }
+  server: appDir,
+  open: true,
+  notify: false,
+  reloadOnRestart: true,
+  files: [
+    p.join(options.assets.root, '**/*.*'),
+    p.join(options.appDir, '**/*.php'),
+    p.join(options.appDir, '**/*.css'),
+    p.join(options.appDir, '**/*.html')
+  ]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
 
 var p = require('path');
 var plugins = require('gulp-load-plugins')({ lazy: true });
-var browserSync = require('browser-sync');
 var tasks = require('./lib/tasks');
 var setupConfig = require('./lib/config/setup.js');
 
@@ -17,10 +16,6 @@ module.exports = function(gulp, options) {
   };
   var config = {};
 
-  // add browser-sync to the plugins so that it can be injected
-  // into all of the dependencies
-  plugins.browserSync = browserSync;
-  
   // Setup the config from the user options
   options = options ? options : {};
   options.appDir = p.dirname(module.parent.filename);

--- a/lib/config/browserSync.js
+++ b/lib/config/browserSync.js
@@ -1,20 +1,19 @@
-var p = require('path');
-var merge = require('../util/mergeOptions.js');
+var p = require('path'),
+    merge = require('../util/mergeOptions.js');
 
 module.exports = function(options) {
+  // See http://www.browsersync.io/docs/options/ for a complete list of configuration options
   var defaults = {
-    useBrowserSync: true,
-    // See http://www.browsersync.io/docs/options/ for a complete list of configuration options
-    settings: {
-      server: true,
-      open: true,
-      notify: false,
-      reloadOnRestart: true,
-      files: [
-        p.join(options.assets.root, '**/*'),
-        p.join(options.appDir, '**/*.php'),
-      ]
-    }
+    server: true,
+    open: true,
+    notify: false,
+    reloadOnRestart: true,
+    files: [
+      p.join(options.assets.root, '**/*.*'),
+      p.join(options.appDir, '**/*.php'),
+      p.join(options.appDir, '**/*.css'),
+      p.join(options.appDir, '**/*.html')
+    ]
   };
 
   return merge('browserSync', options, defaults);

--- a/lib/tasks/browserSync.js
+++ b/lib/tasks/browserSync.js
@@ -1,7 +1,7 @@
+var browserSync = require('browser-sync');
+
 module.exports = function(gulp, plugins, config) {
   return function() {
-  	if (config.browserSync.useBrowserSync) {
-  		plugins.browserSync.init(config.browserSync.settings);
-    }
+		browserSync.init(config.browserSync);
   };
 };

--- a/lib/tasks/browserify.js
+++ b/lib/tasks/browserify.js
@@ -28,7 +28,7 @@ module.exports = function(gulp, plugins, config) {
       .pipe(plugins.uglify, config.uglifyJs.settings)
       .pipe(plugins.filesize)
       .pipe(plugins.debug, {title: 'Minified JS:'});
-    
+
     function reportFinished() {
       bundleLogger.end();
       queue--;
@@ -103,8 +103,7 @@ module.exports = function(gulp, plugins, config) {
         .pipe(plugins.if(config.browserify.uglify, uglifyStream()))
         .on('end', reportFinished)
         // Specify the output destination
-        .pipe(gulp.dest(config.assets.scripts))
-        .pipe(plugins.browserSync.stream());
+        .pipe(gulp.dest(config.assets.scripts));
     }
 
     function getFreshConfig() {

--- a/lib/tasks/images.js
+++ b/lib/tasks/images.js
@@ -6,7 +6,6 @@ module.exports = function(gulp, plugins, config) {
       .pipe(plugins.debug({title: 'Minifying Image:'}))
 			.pipe(plugins.imagemin(config.images.settings))
 			.pipe(gulp.dest(config.assets.images))
-      .pipe(plugins.debug({title: 'Minified Image:'}))
-			.pipe(plugins.browserSync.stream());
+      .pipe(plugins.debug({title: 'Minified Image:'}));
 	}
 };

--- a/lib/tasks/init.js
+++ b/lib/tasks/init.js
@@ -22,9 +22,9 @@ module.exports = function(gulp, plugins, config) {
       var proxy = argv.p || argv.proxy;
       if (proxy) {
         if (proxy === true) {
-          config.browserSync.settings.proxy = 'l.' + p.basename(config.appDir);
+          config.browserSync.proxy = 'l.' + p.basename(config.appDir);
         } else {
-          config.browserSync.settings.proxy = proxy;
+          config.browserSync.proxy = proxy;
         }
       }
 

--- a/lib/tasks/sass.js
+++ b/lib/tasks/sass.js
@@ -9,7 +9,6 @@ module.exports = function(gulp, plugins, config) {
       .pipe(plugins.sourcemaps.write())
       .pipe(plugins.autoprefixer(config.sass.autoprefixer))
       .pipe(gulp.dest(config.assets.styles))
-      .pipe(plugins.debug({title: 'Compiled Sass:'}))
-      .pipe(plugins.browserSync.stream());
+      .pipe(plugins.debug({title: 'Compiled Sass:'}));
   }
 };

--- a/lib/tasks/sprites.js
+++ b/lib/tasks/sprites.js
@@ -6,7 +6,6 @@ module.exports = function(gulp, plugins, config) {
       .pipe(plugins.if('*.png', gulp.dest(config.assets.sprites)))
       .pipe(plugins.if('*.sass', gulp.dest(config.sprites.destSass)))
       .pipe(plugins.if('*.scss', gulp.dest(config.sprites.destSass)))
-      .pipe(plugins.debug({title: 'Sprite created:'}))
-      .pipe(plugins.browserSync.stream());
+      .pipe(plugins.debug({title: 'Sprite created:'}));
   }
 };

--- a/lib/tasks/static.js
+++ b/lib/tasks/static.js
@@ -5,7 +5,6 @@ module.exports = function(gulp, plugins, config) {
 			.pipe(plugins.rename({ extname: "" }))
 			.pipe(plugins.rename({ extname: config.static.extension }))
 			.pipe(gulp.dest(config.assets.static))
-      .pipe(plugins.debug({title: 'Static Files Compiled:'}))
-			.pipe(plugins.browserSync.stream());
+      .pipe(plugins.debug({title: 'Static Files Compiled:'}));
 	}
 };

--- a/lib/tasks/symbols.js
+++ b/lib/tasks/symbols.js
@@ -34,7 +34,6 @@ module.exports = function(gulp, plugins, config) {
 					.pipe(gulp.dest(config.assets.symbols));
 			})
 			.pipe(gulp.dest(config.assets.symbols))
-			.pipe(plugins.debug({title: 'Symbols Created:'}))
-			.pipe(plugins.browserSync.stream());
+			.pipe(plugins.debug({title: 'Symbols Created:'}));
 	};
 };

--- a/lib/util/updateGulpfile.js
+++ b/lib/util/updateGulpfile.js
@@ -2,22 +2,22 @@ var fs = require('fs');
 var appendUserOptions = require('./appendUserOptions');
 
 var addProxy = function(currentOptions, config) {
-  var stringToAdd = "proxy: '" + config.browserSync.settings.proxy + "'",
+  var stringToAdd = "proxy: '" + config.browserSync.proxy + "'",
       browserSync = currentOptions.match(/(browserSync[\s]*?:[\s]*?\{)/g);
 
   // if browserSync options already been declared
   if (browserSync) {
-    var regex = new RegExp(browserSync + '[\\S\\s]+settings[\\s]*?:[\\s]*?\{'),
+    var regex = new RegExp(browserSync + '\{'),
       settings = currentOptions.match(regex);
 
     // if browserSync settings object has been declared
     if (settings) {
       return currentOptions.replace(settings[0], settings[0] + stringToAdd + ",");
     } else {
-      return currentOptions.replace(browserSync[0], browserSync[0] + 'settings: {' + stringToAdd + '},');
+      return currentOptions.replace(browserSync[0], browserSync[0] + stringToAdd + ',');
     }
   } else {
-    return currentOptions.replace('{', '{browserSync: {settings: {' + stringToAdd + '}},');
+    return currentOptions.replace('{', '{browserSync: {' + stringToAdd + '},');
   }
 };
 
@@ -30,7 +30,7 @@ module.exports = function(config, plugins) {
     if (err) throw err;
 
     // if a browserSync proxy has been defined
-    if (config.browserSync.settings.proxy) {
+    if (config.browserSync.proxy) {
       // make sure that a proxy has not already been declared
       if (!data.match(/browserSync[\S\s]+proxy[\S\s]*?\}/g)) {
         data = appendUserOptions(data, config, addProxy);

--- a/lib/util/updateManifest.js
+++ b/lib/util/updateManifest.js
@@ -10,7 +10,9 @@ module.exports = function(config, plugins) {
   fs.readFile(config.init.manifestPath, { encoding: 'utf8' }, function(err, data) {
     if (err) throw err;
 
-    data = JSON.parse(data);
+    // If the file exists but is empty
+    data = data ? JSON.parse(data) : {};
+
     data = merge(data, config.init.stuffToAppend);
 
     fs.writeFile(config.init.manifestPath, JSON.stringify(data, null, 2), function() {


### PR DESCRIPTION
I was testing some other changes, and when running `gulp init` I kept getting an error at `JSON.parse(data)`, so I added a small truthy check. If it's, then continue parsing `data`, if not, just create an empty object.
