### PR TITLE
Fixes #14

### DIFF
--- a/lib/tasks/browserify.js
+++ b/lib/tasks/browserify.js
@@ -96,10 +96,12 @@ module.exports = function(gulp, plugins, config) {
     }
 
     function getFreshConfig() {
+      var bundleConfigPath = p.join(config.appDir, config.browserify.bundleConfig);
+
       // clear the cache for the bundle config
-      delete require.cache[config.browserify.bundleConfig];
+      delete require.cache[bundleConfigPath];
       // get the bundle array
-      bundleConfig = config.browserify.bundleConfig ? require(p.join(config.appDir, config.browserify.bundleConfig)) : config.browserify.bundles;
+      bundleConfig = config.browserify.bundleConfig ? require(bundleConfigPath) : config.browserify.bundles;
       // set the queue to know when we're done
       queue = bundleConfig.length;
 


### PR DESCRIPTION
`getFreshConfig()` wasn't removing the correct index from the require cache. Fixing the index solves the issue and the correct bundle object is getting re-require'd.
