### PR TITLE
Add craftcms gulpfile.js example

### DIFF
--- a/examples/craftcms/gulpfile.js
+++ b/examples/craftcms/gulpfile.js
@@ -1,0 +1,22 @@
+// This file goes in root of your app
+
+var gulp = require('gulp');
+var eta = require('gulp-eta');
+var config = {};
+
+// Scaffold configuration
+config.scaffold = {
+  source: {
+    root: 'craft/_src'
+  },
+  assets: {
+    root: 'public/assets',
+    sass: 'css'
+  }
+};
+
+config.default = {
+  tasks: ['browserSync', 'symbols', 'sass', 'sprites', 'images', 'browserify']
+}
+
+eta(gulp, config);


### PR DESCRIPTION
I've added the example config that I have in the [craft boilerplate](https://github.com/40Digits/craft-boilerplate).
