### PR TITLE
Update Laravel and Rails example to exclude the static task

### DIFF
--- a/examples/laravel/gulpfile.js
+++ b/examples/laravel/gulpfile.js
@@ -15,4 +15,8 @@ config.scaffold = {
   }
 };
 
+config.default = {
+  tasks: ['browserSync', 'symbols', 'sass', 'sprites', 'images', 'browserify']
+}
+
 eta(gulp, config);

--- a/examples/rails/gulpfile.js
+++ b/examples/rails/gulpfile.js
@@ -14,4 +14,8 @@ config.scaffold = {
   }
 };
 
+config.default = {
+  tasks: ['browserSync', 'symbols', 'sass', 'sprites', 'images', 'browserify']
+}
+
 eta(gulp, config);


### PR DESCRIPTION
These frameworks should never use the static tasks.
