### PR TITLE
Fix em() and rem() breaking changes in new node-sass

### DIFF
--- a/lib/_src/sass/utils/functions/_units.scss
+++ b/lib/_src/sass/utils/functions/_units.scss
@@ -18,7 +18,12 @@
       $em-values: append($em-values, $value);
     }
   }
-  @return $em-values;
+
+  @if length($em-values) == 1 {
+    @return nth($em-values, 1); // 1-based
+  } @else {
+    @return $em-values;
+  }
 }
 
 @function rem($px-values, $font-size: $base-font-size) {
@@ -37,5 +42,10 @@
       $rem-values: append($rem-values, $value);
     }
   }
-  @return $rem-values;
+
+  @if length($rem-values) == 1 {
+    @return nth($rem-values, 1); // 1-based
+  } @else {
+    @return $rem-values;
+  }
 }


### PR DESCRIPTION
If the return value from either `em()` or `rem()` functions is a 1-index list, unwrap the value before returning.
